### PR TITLE
feat: bump llm-ls to `0.3.0`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,9 +48,3 @@ jobs:
           PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
           PRIVATE_KEY_PASSWORD: ${{ secrets.PRIVATE_KEY_PASSWORD }}
         run: ./gradlew publishPlugin
-
-      # Upload artifact as a release asset
-      - name: Upload Release Asset
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ github.event.release.tag_name }} ./build/distributions/*

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ pluginUntilBuild = 233.*
 pluginGroup = co.huggingface.llmintellij
 pluginName = llm-intellij
 pluginRepositoryUrl = https://github.com/huggingface/llm-intellij
-pluginVersion = 0.0.2
+pluginVersion = 0.0.3
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IU

--- a/src/main/kotlin/co/huggingface/llmintellij/LlmSettingsComponent.kt
+++ b/src/main/kotlin/co/huggingface/llmintellij/LlmSettingsComponent.kt
@@ -210,7 +210,7 @@ class LlmSettingsComponent {
         llmLsSubsectionPanel.add(lspBinaryPathLabel)
         llmLsSubsectionPanel.add(lspBinaryPath)
         lspVersionLabel = JBLabel("Version")
-        lspVersion = JBTextField("0.2.2")
+        lspVersion = JBTextField("0.3.0")
         llmLsSubsectionPanel.add(lspVersionLabel)
         llmLsSubsectionPanel.add(lspVersion)
         lspLogLevelLabel = JBLabel("Log level")

--- a/src/main/kotlin/co/huggingface/llmintellij/LlmSettingsState.kt
+++ b/src/main/kotlin/co/huggingface/llmintellij/LlmSettingsState.kt
@@ -9,7 +9,7 @@ import com.intellij.util.xmlb.XmlSerializerUtil
 
 class LspSettings {
     var binaryPath: String? = null
-    var version: String = "0.2.2"
+    var version: String = "0.3.0"
     var logLevel: String = "warn"
 }
 


### PR DESCRIPTION
llm-ls now supports AST parsing to improve suggestions. Based on the cursor's position the AST, suggestions will be empty (no suggestion), single line or multi line.