### PR TITLE
feat: bump llm-ls to `0.4.0`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,56 +87,6 @@ jobs:
           name: ${{ steps.artifact.outputs.filename }}
           path: ./build/distributions/content/*/*
 
-  # Run plugin structure verification along with IntelliJ Plugin Verifier
-  verify:
-    name: Verify plugin
-    needs: [ build ]
-    runs-on: ubuntu-latest
-    steps:
-
-      # Free GitHub Actions Environment Disk Space
-      - name: Maximize Build Space
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: false
-          large-packages: false
-
-      # Check out current repository
-      - name: Fetch Sources
-        uses: actions/checkout@v4
-
-      # Set up Java environment for the next steps
-      - name: Setup Java
-        uses: actions/setup-java@v3
-        with:
-          distribution: zulu
-          java-version: 17
-
-      # Setup Gradle
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-        with:
-          gradle-home-cache-cleanup: true
-
-      # Cache Plugin Verifier IDEs
-      - name: Setup Plugin Verifier IDEs Cache
-        uses: actions/cache@v3
-        with:
-          path: ${{ needs.build.outputs.pluginVerifierHomeDir }}/ides
-          key: plugin-verifier-${{ hashFiles('build/listProductsReleases.txt') }}
-
-      # Run Verify Plugin task and IntelliJ Plugin Verifier tool
-      - name: Run Plugin Verification tasks
-        run: ./gradlew runPluginVerifier -Dplugin.verifier.home.dir=${{ needs.build.outputs.pluginVerifierHomeDir }}
-
-      # Collect Plugin Verifier Result
-      - name: Collect Plugin Verifier Result
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: pluginVerifier-result
-          path: ${{ github.workspace }}/build/reports/pluginVerifier
-
   # Run tests and upload a code coverage report
   test:
     name: Test

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ pluginUntilBuild = 233.*
 pluginGroup = co.huggingface.llmintellij
 pluginName = llm-intellij
 pluginRepositoryUrl = https://github.com/huggingface/llm-intellij
-pluginVersion = 0.0.1
+pluginVersion = 0.0.2
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IU

--- a/src/main/kotlin/co/huggingface/llmintellij/LlmLsCompletionProvider.kt
+++ b/src/main/kotlin/co/huggingface/llmintellij/LlmLsCompletionProvider.kt
@@ -15,7 +15,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 
 class LlmLsCompletionProvider: InlineCompletionProvider {
@@ -40,10 +39,10 @@ class LlmLsCompletionProvider: InlineCompletionProvider {
                     val fimParams = settings.fim
                     val tokenizerConfig = settings.tokenizer
                     val params = CompletionParams(textDocument, position, request_params = queryParams, fim = fimParams, api_token = secrets.getSecretSetting(), model = settings.model, tokens_to_clear = settings.tokensToClear, tokenizer_config = tokenizerConfig, context_window = settings.contextWindow)
-                    lspServer.requestExecutor.sendRequestAsync(LlmLsGetCompletionsRequest(lspServer, params)) { completions ->
+                    lspServer.requestExecutor.sendRequestAsync(LlmLsGetCompletionsRequest(lspServer, params)) { response ->
                         CoroutineScope(Dispatchers.Default).launch {
-                            if (completions != null) {
-                                for (completion in completions) {
+                            if (response != null) {
+                                for (completion in response.completions) {
                                     send(InlineCompletionElement(completion.generated_text))
                                 }
                             }

--- a/src/main/kotlin/co/huggingface/llmintellij/LlmSettingsComponent.kt
+++ b/src/main/kotlin/co/huggingface/llmintellij/LlmSettingsComponent.kt
@@ -210,7 +210,7 @@ class LlmSettingsComponent {
         llmLsSubsectionPanel.add(lspBinaryPathLabel)
         llmLsSubsectionPanel.add(lspBinaryPath)
         lspVersionLabel = JBLabel("Version")
-        lspVersion = JBTextField("0.3.0")
+        lspVersion = JBTextField("0.4.0")
         llmLsSubsectionPanel.add(lspVersionLabel)
         llmLsSubsectionPanel.add(lspVersion)
         lspLogLevelLabel = JBLabel("Log level")

--- a/src/main/kotlin/co/huggingface/llmintellij/LlmSettingsState.kt
+++ b/src/main/kotlin/co/huggingface/llmintellij/LlmSettingsState.kt
@@ -9,7 +9,7 @@ import com.intellij.util.xmlb.XmlSerializerUtil
 
 class LspSettings {
     var binaryPath: String? = null
-    var version: String = "0.3.0"
+    var version: String = "0.4.0"
     var logLevel: String = "warn"
 }
 

--- a/src/main/kotlin/co/huggingface/llmintellij/lsp/Completion.kt
+++ b/src/main/kotlin/co/huggingface/llmintellij/lsp/Completion.kt
@@ -1,3 +1,8 @@
 package co.huggingface.llmintellij.lsp
 
 class Completion(val generated_text: String)
+
+class CompletionResponse {
+    val request_id: String = ""
+    val completions: List<Completion> = emptyList()
+}

--- a/src/main/kotlin/co/huggingface/llmintellij/lsp/LlmLsGetCompletionsRequest.kt
+++ b/src/main/kotlin/co/huggingface/llmintellij/lsp/LlmLsGetCompletionsRequest.kt
@@ -4,7 +4,7 @@ import com.intellij.platform.lsp.api.LspServer
 import com.intellij.platform.lsp.api.requests.LspRequest
 import java.util.concurrent.CompletableFuture
 
-class LlmLsGetCompletionsRequest(lspServer: LspServer, private val params: CompletionParams): LspRequest<List<Completion>, List<Completion>>(lspServer) {
-    override fun sendRequest(): CompletableFuture<List<Completion>> = (lspServer.lsp4jServer as LlmLsLanguageServer).getCompletions(params)
-    override fun preprocessResponse(serverResponse: List<Completion>) = serverResponse
+class LlmLsGetCompletionsRequest(lspServer: LspServer, private val params: CompletionParams): LspRequest<CompletionResponse, CompletionResponse>(lspServer) {
+    override fun sendRequest(): CompletableFuture<CompletionResponse> = (lspServer.lsp4jServer as LlmLsLanguageServer).getCompletions(params)
+    override fun preprocessResponse(serverResponse: CompletionResponse) = serverResponse
 }

--- a/src/main/kotlin/co/huggingface/llmintellij/lsp/LlmLsLanguageServer.kt
+++ b/src/main/kotlin/co/huggingface/llmintellij/lsp/LlmLsLanguageServer.kt
@@ -30,5 +30,5 @@ class CompletionParams(
 @JsonSegment("llm-ls")
 public interface LlmLsLanguageServer: LanguageServer {
     @JsonRequest
-    fun getCompletions(params: CompletionParams): CompletableFuture<List<Completion>>;
+    fun getCompletions(params: CompletionParams): CompletableFuture<CompletionResponse>;
 }


### PR DESCRIPTION
Response object changed in `0.4.0`, and adds `acceptCompletion` & `rejectCompletion` calls, for additional logging. Though it does not seem to be possible to subscribe to accept & reject events in the `InlineCompletionProvider` provided by the intellij platform, so I haven't implemented the calls yet.

Linked to https://github.com/huggingface/llm-ls/pull/34