### PR TITLE
Fix Ignoring binaryPath if binary doesn't end in version

### DIFF
--- a/src/main/kotlin/co/huggingface/llmintellij/lsp/LlmLsLspServerDescriptor.kt
+++ b/src/main/kotlin/co/huggingface/llmintellij/lsp/LlmLsLspServerDescriptor.kt
@@ -101,7 +101,7 @@ fun runCommand(command: String) {
 }
 
 fun downloadLlmLs(logger: Logger, binaryPath: String?, version: String): String? {
-    if (binaryPath != null && binaryPath.endsWith(version) && File(binaryPath).exists()) {
+    if (binaryPath != null && File(binaryPath).exists()) {
         return binaryPath
     }
 


### PR DESCRIPTION
When setting a option like `<option name="binaryPath" value="C:\bins\llm-ls" />` it would be ignored.
Currently the [llm-ls](https://github.com/huggingface/llm-ls/releases/tag/0.4.0) release for windows only returns 2 files:
```
llm-ls.exe
llm_ls.pdb
```
inducing user error of setting the path directly to `%randomPath%/llm-ls.exe` and failing the if check