### PR TITLE
Remove linux commands, respect tls_skip_insecure as completionParam and set correct arch on amd64

### DIFF
--- a/src/main/kotlin/co/huggingface/llmintellij/LlmLsCompletionProvider.kt
+++ b/src/main/kotlin/co/huggingface/llmintellij/LlmLsCompletionProvider.kt
@@ -38,7 +38,7 @@ class LlmLsCompletionProvider: InlineCompletionProvider {
                     val queryParams = settings.queryParams
                     val fimParams = settings.fim
                     val tokenizerConfig = settings.tokenizer
-                    val params = CompletionParams(textDocument, position, request_params = queryParams, fim = fimParams, api_token = secrets.getSecretSetting(), model = settings.model, tokens_to_clear = settings.tokensToClear, tokenizer_config = tokenizerConfig, context_window = settings.contextWindow)
+                    val params = CompletionParams(textDocument, position, request_params = queryParams, fim = fimParams, api_token = secrets.getSecretSetting(), model = settings.model, tokens_to_clear = settings.tokensToClear, tokenizer_config = tokenizerConfig, context_window = settings.contextWindow, tls_skip_verify_insecure = settings.tlsSkipVerifyInsecure)
                     lspServer.requestExecutor.sendRequestAsync(LlmLsGetCompletionsRequest(lspServer, params)) { response ->
                         CoroutineScope(Dispatchers.Default).launch {
                             if (response != null) {

--- a/src/main/kotlin/co/huggingface/llmintellij/lsp/LlmLsLspServerDescriptor.kt
+++ b/src/main/kotlin/co/huggingface/llmintellij/lsp/LlmLsLspServerDescriptor.kt
@@ -11,10 +11,7 @@ import org.eclipse.lsp4j.services.LanguageServer
 import java.io.*
 import java.net.*
 import java.nio.file.Files
-import java.security.cert.X509Certificate
 import java.util.zip.GZIPInputStream
-import javax.net.ssl.TrustManager
-import javax.net.ssl.X509TrustManager
 import kotlin.io.path.Path
 import kotlin.io.path.deleteIfExists
 
@@ -172,12 +169,6 @@ fun downloadAndUnzip(logger: Logger, url: String, binDir: File, binName: String,
     }
 
     Path(zipPath).deleteIfExists()
-}
-
-fun runCommand(command: String) {
-    val process = Runtime.getRuntime().exec(command)
-
-    process.waitFor()
 }
 
 fun downloadLlmLs(logger: Logger, binaryPath: String?, version: String): String? {

--- a/src/main/kotlin/co/huggingface/llmintellij/lsp/LlmLsLspServerDescriptor.kt
+++ b/src/main/kotlin/co/huggingface/llmintellij/lsp/LlmLsLspServerDescriptor.kt
@@ -118,7 +118,7 @@ private val trustAllCerts = arrayOf<TrustManager>(object : X509TrustManager {
 }
 )
 
-fun downloadFile(urlString: String, outputPath: String) {
+fun downloadFile(logger: Logger, urlString: String, outputPath: String) {
     try {
         val url = URL(urlString)
 
@@ -153,15 +153,15 @@ fun downloadFile(urlString: String, outputPath: String) {
             inputStream.close()
             outputStream.close()
 
-            println("File downloaded successfully.")
+            logger.info("File downloaded successfully.")
         } else {
-            println("Failed to download file. Response Code: ${connection.responseCode}")
+            logger.error("Failed to download file. Response Code: ${connection.responseCode}")
         }
 
         // Disconnect the connection
         connection.disconnect()
     } catch (e: Exception) {
-        println("Error: ${e.message}")
+        logger.error("Error: ${e.message}")
     }
 }
 
@@ -170,13 +170,15 @@ fun downloadAndUnzip(logger: Logger, url: String, binDir: File, binName: String,
     val extractedBinPath = File(binDir, binName).absolutePath
     val zipPath = "$extractedBinPath.gz"
 
-    downloadFile(url, zipPath)
+    downloadFile(logger, url, zipPath)
 
     try {
         val inputByteStream = FileInputStream(zipPath)
         val outputByteStream = FileOutputStream(extractedBinPath)
 
         outputByteStream.write(GZIPInputStream(inputByteStream).use { it.readBytes() })
+        inputByteStream.close()
+        outputByteStream.close()
         logger.info("Successfully extracted llm-ls")
     } catch (e: Exception)
     {

--- a/src/main/kotlin/co/huggingface/llmintellij/lsp/LlmLsLspServerDescriptor.kt
+++ b/src/main/kotlin/co/huggingface/llmintellij/lsp/LlmLsLspServerDescriptor.kt
@@ -7,21 +7,12 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.platform.lsp.api.ProjectWideLspServerDescriptor
 import io.ktor.util.*
-import org.apache.http.HttpHost
-import org.apache.http.client.methods.HttpGet
-import org.apache.http.impl.client.HttpClientBuilder
-import org.apache.http.impl.client.LaxRedirectStrategy
 import org.eclipse.lsp4j.services.LanguageServer
 import java.io.*
 import java.net.*
-import java.net.http.HttpClient
-import java.net.http.HttpRequest
-import java.net.http.HttpResponse
 import java.nio.file.Files
-import java.security.SecureRandom
 import java.security.cert.X509Certificate
 import java.util.zip.GZIPInputStream
-import javax.net.ssl.SSLContext
 import javax.net.ssl.TrustManager
 import javax.net.ssl.X509TrustManager
 import kotlin.io.path.Path
@@ -100,23 +91,6 @@ fun buildBinaryName(logger: Logger): String? {
 fun buildUrl(binName: String, version: String): String {
     return "https://github.com/huggingface/llm-ls/releases/download/$version/$binName.gz"
 }
-
-private val trustAllCerts = arrayOf<TrustManager>(object : X509TrustManager {
-    override fun getAcceptedIssuers(): Array<X509Certificate>? {
-        return null
-    }
-
-    override fun checkClientTrusted(
-        certs: Array<X509Certificate>, authType: String
-    ) {
-    }
-
-    override fun checkServerTrusted(
-        certs: Array<X509Certificate>, authType: String
-    ) {
-    }
-}
-)
 
 fun downloadFile(logger: Logger, urlString: String, outputPath: String) {
     try {


### PR DESCRIPTION
I changed the `runCommand` part to kotlin/java code, so that the `llm-ls` download also works under windows, and if `curl` is not installed (newer Ubuntu verions). It also respects proxy and certificate settings.

In my two tested Ubuntu versions the architecture was `amd64`, where no `llm-ls` is available. I added a hardcoded conversion to  `x86_64`.

I also realised, that the `llm-ls` has a `tls_skip_verify_insecure` `CompletionParameter` prepared and the plugin also has the setting, but it was not sent in the completion request to the `llm-ls`. This setting/parameter will be sent now.

The only thing still open are the proxy settings for the `llm-ls`. I actually set the `https_proxy` environment variable before I launch the Idea, but it would be much nicer, if the plugin could do this to. But up to now I could not read the proxy settings of the IDE.

I hope this helps and the quality of the code is ok. ;-)